### PR TITLE
Better draw filled polygons

### DIFF
--- a/src/hagl_polygon.c
+++ b/src/hagl_polygon.c
@@ -89,7 +89,7 @@ hagl_fill_polygon(void const *_surface, int16_t amount, int16_t *vertices, hagl_
     }
 
     /*  Loop through the rows of the image. */
-    for (y = miny; y < maxy; y++) {
+    for (y = miny; y <= maxy; y++) {
 
         /*  Build a list of nodes. */
         int16_t count = 0;
@@ -107,6 +107,13 @@ hagl_fill_polygon(void const *_surface, int16_t amount, int16_t *vertices, hagl_
             ) {
                 nodes[count] = (int16_t)(x0 + (y - y0) / (y1 - y0) * (x1 - x0));
                 count++;
+            }
+            /*  Draw horizonlat lines. */
+            else if(y == y0 && y == y1) {
+                if(x0 < x1)
+                    hagl_draw_hline(surface, x0, y0, x1 - x0 + 1, color);
+                else
+                    hagl_draw_hline(surface, x1, y0, x0 - x1 + 1, color);
             }
             j = i;
         }
@@ -128,7 +135,7 @@ hagl_fill_polygon(void const *_surface, int16_t amount, int16_t *vertices, hagl_
 
         /* Draw lines between nodes. */
         for (int16_t i = 0; i < count; i += 2) {
-            int16_t width = nodes[i + 1] - nodes[i];
+            int16_t width = nodes[i + 1] - nodes[i] + 1;
             hagl_draw_hline(surface, nodes[i], y, width, color);
         }
     }


### PR DESCRIPTION
I want polygon exact the same to rectangle with the same vertices

Example:
`

			int16_t vertices[] = {
				5, 5,
				5, 7,
				7, 7,
				7, 5
			};
			hagl_fill_rectangle(display, vertices[0], vertices[1], vertices[4], vertices[5], LCD_COLOR_WHITE);
			hagl_fill_polygon(display, 4, vertices, LCD_COLOR_GREEN);
`

Before changes:
<img width="54" height="59" alt="obraz" src="https://github.com/user-attachments/assets/ad5ff748-d63c-484f-94bd-6c40eca0e88d" />

After changes:
<img width="54" height="59" alt="obraz" src="https://github.com/user-attachments/assets/6edb819f-fb60-4fff-8974-1ac3289c6fb7" />
