### PR TITLE
Pass pointer to struct instead of pointer to pointer

### DIFF
--- a/src/hagl_blit.c
+++ b/src/hagl_blit.c
@@ -64,7 +64,7 @@ hagl_blit_xy(void const *_surface, int16_t x0, int16_t y0, hagl_bitmap_t *source
             }
         } else {
             /* Inside of bounds, can use HAL provided blit. */
-            surface->blit(&surface, x0, y0, source);
+            surface->blit((void *)_surface, x0, y0, source);
         }
     } else {
         hagl_color_t color;
@@ -85,7 +85,7 @@ hagl_blit_xywh(void const *_surface, uint16_t x0, uint16_t y0, uint16_t w, uint1
     const hagl_surface_t *surface = _surface;
 
     if (surface->scale_blit) {
-        surface->scale_blit(&surface, x0, y0, w, h, source);
+        surface->scale_blit((void *)_surface, x0, y0, w, h, source);
     } else {
         hagl_color_t color;
         hagl_color_t *ptr = (hagl_color_t *) source->buffer;

--- a/src/hagl_color.c
+++ b/src/hagl_color.c
@@ -42,7 +42,7 @@ hagl_color(void const *_surface, uint8_t r, uint8_t g, uint8_t b)
     const hagl_surface_t *surface = _surface;
 
     if (surface->color) {
-        return surface->color(&surface, r, g, b);
+        return surface->color((void *)_surface, r, g, b);
     }
     return rgb565(r, g, b);
 }

--- a/src/hagl_hline.c
+++ b/src/hagl_hline.c
@@ -65,7 +65,7 @@ hagl_draw_hline_xyw(void const *_surface, int16_t x0, int16_t y0, uint16_t w, ha
             width = width - (x0 + width - 1 - surface->clip.x1);
         }
 
-        surface->hline(&surface, x0, y0, width, color);
+        surface->hline((void *)_surface, x0, y0, width, color);
     } else {
         hagl_draw_line(surface, x0, y0, x0 + w - 1, y0, color);
     }

--- a/src/hagl_pixel.c
+++ b/src/hagl_pixel.c
@@ -52,7 +52,7 @@ hagl_put_pixel(void const *_surface, int16_t x0, int16_t y0, hagl_color_t color)
     }
 
     /* If still in bounds set the pixel. */
-    surface->put_pixel(&surface, x0, y0, color);
+    surface->put_pixel((void *)_surface, x0, y0, color);
 }
 
 hagl_color_t
@@ -69,7 +69,7 @@ hagl_get_pixel(void const *_surface, int16_t x0, int16_t y0) {
     }
 
     if (surface->get_pixel) {
-        return surface->get_pixel(&surface, x0, y0);
+        return surface->get_pixel((void *)_surface, x0, y0);
     }
 
     return hagl_color(surface, 0, 0, 0);

--- a/src/hagl_rectangle.c
+++ b/src/hagl_rectangle.c
@@ -121,7 +121,7 @@ hagl_fill_rectangle_xyxy(void const *_surface, int16_t x0, int16_t y0, int16_t x
     for (uint16_t i = 0; i < height; i++) {
         if (surface->hline) {
             /* Already clipped so can call HAL directly. */
-            surface->hline(&surface, x0, y0 + i, width, color);
+            surface->hline((void *)_surface, x0, y0 + i, width, color);
         } else {
             hagl_draw_hline(surface, x0, y0 + i, width, color);
         }

--- a/src/hagl_vline.c
+++ b/src/hagl_vline.c
@@ -65,7 +65,7 @@ hagl_draw_vline_xyh(void const *_surface, int16_t x0, int16_t y0, uint16_t h, ha
             height = height - (y0 + height - 1 - surface->clip.y1);
         }
 
-        surface->vline(&surface, x0, y0, height, color);
+        surface->vline((void *)_surface, x0, y0, height, color);
     } else {
         hagl_draw_line(surface, x0, y0, x0, y0 + h - 1, color);
     }


### PR DESCRIPTION
Before the callback received a pointer-to-a-pointer instead of a
pointer-to-the-struct. This was not caught because every existing
HAL the callback ignores the self parameter.

Consider this a noob mistake.
